### PR TITLE
Add an "AddModule" line in speechd.conf for voxin

### DIFF
--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -242,6 +242,7 @@ DefaultVolume 100
 #AddModule "mary-generic"             "sd_generic"   "mary-generic.conf"
 #AddModule "baratinoo"                "sd_baratinoo" "baratinoo.conf"
 #AddModule "rhvoice"                  "sd_rhvoice"   "rhvoice.conf"
+#AddModule "voxin"                    "sd_voxin"     "voxin.conf"
 
 # DO NOT REMOVE the following line unless you have
 # a specific reason -- this is the fallback output module


### PR DESCRIPTION
Oralux intends to ship its voxin module and configuration file with the name voxin to avoid conflicting naming with ibmtts.